### PR TITLE
removed "function" keyword from function definition

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function usage() {
+usage() {
 cat <<EOT
 usage: $0 [-h|--help] (single|swarm target-node) <docker-compose command>
 	-h, --help: show this message and exit


### PR DESCRIPTION
Removed the keyword function as it is the "sh way" of defining functions.
I will be compatible with more shells/systems like this.

